### PR TITLE
Fix: Support multiple values for repeated CLI optionsFix/multiple option values

### DIFF
--- a/src/Console/Input/InputParser.php
+++ b/src/Console/Input/InputParser.php
@@ -40,7 +40,7 @@ final class InputParser
             // --option or --option=value
             if (str_starts_with((string) $item, '--')) {
                 [$name, $value] = $this->parseLongOption($item, $argv);
-                $options[$name] = $value;
+                $this->addOptionValue($options, $name, $value);
                 continue;
             }
 
@@ -75,5 +75,26 @@ final class InputParser
         }
 
         return [$item, true];
+    }
+
+    /**
+     * Add option value to the options array, handling multiple values for the same option name.
+     *
+     * @param array<string, mixed> $options
+     * @param mixed $value
+     */
+    private function addOptionValue(array &$options, string $name, mixed $value): void
+    {
+        if (! array_key_exists($name, $options)) {
+            $options[$name] = $value;
+            return;
+        }
+
+        // handle multiple values for the same option
+        if (! is_array($options[$name])) {
+            $options[$name] = [$options[$name]];
+        }
+
+        $options[$name][] = $value;
     }
 }

--- a/tests/Console/Input/InputParserTest.php
+++ b/tests/Console/Input/InputParserTest.php
@@ -43,12 +43,7 @@ final class InputParserTest extends TestCase
     {
         $inputParser = new InputParser();
 
-        $cliRequest = $inputParser->parse([
-            'bin/jack',
-            'breakpoint',
-            '--ignore=symfony/',
-            '--dev',
-        ]);
+        $cliRequest = $inputParser->parse(['bin/jack', 'breakpoint', '--ignore=symfony/', '--dev']);
 
         $this->assertSame('breakpoint', $cliRequest->getCommandName());
         $this->assertSame([], $cliRequest->getArguments());

--- a/tests/Console/Input/InputParserTest.php
+++ b/tests/Console/Input/InputParserTest.php
@@ -19,4 +19,63 @@ final class InputParserTest extends TestCase
         $this->assertSame(['src'], $cliRequest->getArguments());
         $this->assertSame([], $cliRequest->getOptions());
     }
+
+    public function testMultipleValuesForSameOption(): void
+    {
+        $inputParser = new InputParser();
+
+        $cliRequest = $inputParser->parse([
+            'bin/jack',
+            'breakpoint',
+            '--ignore=symfony/',
+            '--ignore=doctrine/',
+            '--ignore=phpunit/',
+        ]);
+
+        $this->assertSame('breakpoint', $cliRequest->getCommandName());
+        $this->assertSame([], $cliRequest->getArguments());
+        $this->assertSame([
+            'ignore' => ['symfony/', 'doctrine/', 'phpunit/'],
+        ], $cliRequest->getOptions());
+    }
+
+    public function testSingleOptionValueRemainsAsScalar(): void
+    {
+        $inputParser = new InputParser();
+
+        $cliRequest = $inputParser->parse([
+            'bin/jack',
+            'breakpoint',
+            '--ignore=symfony/',
+            '--dev',
+        ]);
+
+        $this->assertSame('breakpoint', $cliRequest->getCommandName());
+        $this->assertSame([], $cliRequest->getArguments());
+        $this->assertSame([
+            'ignore' => 'symfony/',
+            'dev' => true,
+        ], $cliRequest->getOptions());
+    }
+
+    public function testMultipleOptionsWithMixedFormats(): void
+    {
+        $inputParser = new InputParser();
+
+        $cliRequest = $inputParser->parse([
+            'bin/jack',
+            'process',
+            '--path=src',
+            '--path=tests',
+            '--dev',
+            'extra-arg',
+        ]);
+
+        $this->assertSame('process', $cliRequest->getCommandName());
+        $this->assertSame(['extra-arg'], $cliRequest->getArguments());
+        $this->assertSame([
+            'path' => ['src', 'tests'],
+            'dev' => true,
+        ], $cliRequest->getOptions());
+    }
 }

--- a/tests/Console/Input/InputParserTest.php
+++ b/tests/Console/Input/InputParserTest.php
@@ -58,23 +58,24 @@ final class InputParserTest extends TestCase
         ], $cliRequest->getOptions());
     }
 
-    public function testMultipleOptionsWithMixedFormats(): void
+    public function testMultipleOptionsWithArguments(): void
     {
         $inputParser = new InputParser();
 
         $cliRequest = $inputParser->parse([
             'bin/jack',
             'process',
-            '--path=src',
-            '--path=tests',
+            'src',
+            'tests',
+            '--path=dir1',
+            '--path=dir2',
             '--dev',
-            'extra-arg',
         ]);
 
         $this->assertSame('process', $cliRequest->getCommandName());
-        $this->assertSame(['extra-arg'], $cliRequest->getArguments());
+        $this->assertSame(['src', 'tests'], $cliRequest->getArguments());
         $this->assertSame([
-            'path' => ['src', 'tests'],
+            'path' => ['dir1', 'dir2'],
             'dev' => true,
         ], $cliRequest->getOptions());
     }


### PR DESCRIPTION
## Problem
When using repeated options like `--ignore=value1 --ignore=value2`, only the last value is kept because the parser overwrites previous values.

## Solution
- Check if option key already exists in the options array
- If it exists, convert to array (if not already) and append new value
- Extracted logic to `addOptionValue()` method for better readability

## Example
```bash
# Before: only 'doctrine/' would be kept
vendor/bin/jack breakpoint --ignore=symfony/ --ignore=doctrine/

# After: both values are kept as array ['symfony/', 'doctrine/']
```

## Related
This matches standard CLI behavior from:
Symfony Console (InputOption::VALUE_IS_ARRAY)
Docker (-e KEY1=val1 -e KEY2=val2)
Git (--author=John --author=Jane)
Fixes issue with rector/jack breakpoint command and multiple --ignore options.