### PR TITLE
Render progress bar without color

### DIFF
--- a/src/Console/Output/ProgressBar.php
+++ b/src/Console/Output/ProgressBar.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Entropy\Console\Output;
 
 use Entropy\Attributes\RelatedTest;
-use Entropy\Console\Enum\Color;
 use Entropy\Tests\Console\Output\ProgressBarTest;
 
 /**
@@ -27,9 +26,8 @@ final class ProgressBar
 
     private readonly bool $isSilent;
 
-    public function __construct(
-        private readonly OutputColorizer $outputColorizer
-    ) {
+    public function __construct()
+    {
         // avoid printing to stdout during unit tests
         $this->isSilent = defined('PHPUNIT_COMPOSER_INSTALL');
     }
@@ -97,6 +95,6 @@ final class ProgressBar
         }
 
         // \r returns the cursor to the line start, so the bar is re-written in place
-        fwrite(STDOUT, "\r" . $this->outputColorizer->color($this->render(), Color::GREEN));
+        fwrite(STDOUT, "\r" . $this->render());
     }
 }

--- a/tests/Console/Output/ProgressBarTest.php
+++ b/tests/Console/Output/ProgressBarTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Entropy\Tests\Console\Output;
 
-use Entropy\Console\Output\OutputColorizer;
 use Entropy\Console\Output\ProgressBar;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +13,7 @@ final class ProgressBarTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->progressBar = new ProgressBar(new OutputColorizer());
+        $this->progressBar = new ProgressBar();
     }
 
     public function testStartRendersZeroPercent(): void


### PR DESCRIPTION
The progress bar was hardcoded to green. This renders it plainly (no color), so it uses the terminal's default foreground.

- Drop the `Color::GREEN` wrapping in `ProgressBar::display()`
- Remove the now-unused `OutputColorizer` constructor dependency
- Update `ProgressBarTest` accordingly

Needed by tomasvotruba/lines#72.