### PR TITLE
Parse the value of a long option in leading position

### DIFF
--- a/src/Console/Input/InputParser.php
+++ b/src/Console/Input/InputParser.php
@@ -28,8 +28,14 @@ final class InputParser
         $options = [];
 
         $command = array_shift($argv);
-        if (str_starts_with((string) $command, '-')) {
-            // most likely an option
+        if (str_starts_with((string) $command, '--')) {
+            // most likely an option, possibly carrying a value, e.g. "--limit=5" or "--limit 5"
+            [$name, $value] = $this->parseLongOption((string) $command, $argv);
+
+            $options[$name] = $value;
+            $command = null;
+        } elseif (str_starts_with((string) $command, '-')) {
+            // most likely a short flag
             $options[ltrim((string) $command, '-')] = true;
             $command = null;
         }

--- a/tests/Console/Input/InputParserTest.php
+++ b/tests/Console/Input/InputParserTest.php
@@ -71,4 +71,36 @@ final class InputParserTest extends TestCase
             'help' => true,
         ], $cliRequest->getOptions());
     }
+
+    public function testFirstTokenLongOptionWithInlineValue(): void
+    {
+        $cliRequest = $this->inputParser->parse(['bin/rector', '--limit=5']);
+
+        $this->assertNull($cliRequest->getCommandName());
+        $this->assertSame([
+            'limit' => '5',
+        ], $cliRequest->getOptions());
+    }
+
+    public function testFirstTokenLongOptionWithSeparatedValue(): void
+    {
+        $cliRequest = $this->inputParser->parse(['bin/rector', '--directory', 'some-path']);
+
+        $this->assertNull($cliRequest->getCommandName());
+        $this->assertSame([], $cliRequest->getArguments());
+        $this->assertSame([
+            'directory' => 'some-path',
+        ], $cliRequest->getOptions());
+    }
+
+    public function testFirstTokenLongOptionFollowedByMore(): void
+    {
+        $cliRequest = $this->inputParser->parse(['bin/rector', '--limit=5', '--directory', 'some-path']);
+
+        $this->assertNull($cliRequest->getCommandName());
+        $this->assertSame([
+            'limit' => '5',
+            'directory' => ['some-path'],
+        ], $cliRequest->getOptions());
+    }
 }


### PR DESCRIPTION
A long option passed as the *first* token was recorded with a bare `ltrim()`, so the `=` was never split off — the whole token became the option name and the value was lost.

For any application with a default command, that turns a valid invocation into an error:

```bash
$ vendor/bin/phpstan-bodyscan --min-level=0
Run failed: Unknown option: "--min-level=0"
```

`--min-level=0` was parsed as the option `min-level=0` with the value `true`, so `CLIRequestMapper` never matched it against the `$minLevel` parameter and reported it as unknown.

## Fix

Route the leading token through `parseLongOption()`, the same method the main loop already uses. Short flags keep their existing handling.

```diff
 $command = array_shift($argv);
-if (str_starts_with((string) $command, '-')) {
-    // most likely an option
+if (str_starts_with((string) $command, '--')) {
+    // most likely an option, possibly carrying a value, e.g. "--limit=5" or "--limit 5"
+    [$name, $value] = $this->parseLongOption((string) $command, $argv);
+
+    $options[$name] = $value;
+    $command = null;
+} elseif (str_starts_with((string) $command, '-')) {
+    // most likely a short flag
     $options[ltrim((string) $command, '-')] = true;
     $command = null;
 }
```

Both value forms now resolve, and the separated form no longer leaks its value into the positional arguments:

| Input | Before | After |
| --- | --- | --- |
| `--limit=5` | `['limit=5' => true]` | `['limit' => '5']` |
| `--directory some-path` | `['directory' => true]`, `some-path` left as an argument | `['directory' => 'some-path']` |
| `--help` | `['help' => true]` | unchanged |
| `-h` | `['h' => true]` | unchanged |

## Tests

Three cases added to `InputParserTest` — inline value, separated value, and a leading option followed by more options. The existing `testFirstTokenShortFlag` and `testFirstTokenLongFlag` expectations are unchanged.