### PR TITLE
Add factory-less registration and list results to findByContract

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -47,6 +47,12 @@ class Container
      */
     private array $makingStack = [];
 
+    /**
+     * Classes registered for autowiring and contract discovery, without a factory.
+     * @var array<class-string, true>
+     */
+    private array $registeredClasses = [];
+
     public function __construct()
     {
         // setup default console service
@@ -100,7 +106,26 @@ class Container
             throw new RegisterServiceException(sprintf('Service for "%s" class is already registered', $class));
         }
 
+        // a factory supersedes a bare registration of the same class
+        unset($this->registeredClasses[$class]);
+
         $this->serviceFactories[$class] = $factory;
+    }
+
+    /**
+     * Register a class for autowiring and contract discovery, without a factory. The container builds it
+     * via reflection on demand, and findByContract() can then find it among its implementations.
+     * Idempotent, unlike service(); a class already backed by a factory is left untouched.
+     *
+     * @param class-string $class
+     */
+    public function register(string $class): void
+    {
+        if (isset($this->serviceFactories[$class])) {
+            return;
+        }
+
+        $this->registeredClasses[$class] = true;
     }
 
     /**
@@ -164,13 +189,20 @@ class Container
      * @template TType as object
      *
      * @param class-string<TType> $contractClass
-     * @return array<TType>
+     * @return list<TType>
      */
     public function findByContract(string $contractClass): array
     {
         $this->warmUpInstanceServices($contractClass);
 
-        return array_filter($this->instances, fn (object $instance): bool => $instance instanceof $contractClass);
+        $matches = array_filter(
+            $this->instances,
+            fn (object $instance): bool => $instance instanceof $contractClass
+        );
+
+        // return a plain 0-indexed list; class-string keys would turn a variadic spread
+        // (e.g. new Traverser(...$services)) into named arguments
+        return array_values($matches);
     }
 
     /**
@@ -197,18 +229,20 @@ class Container
 
     private function warmUpInstanceServices(string $contractClass): void
     {
-        // warm up instances with registered service of contract
-        foreach (array_keys($this->serviceFactories) as $class) {
-            if (! is_a($class, $contractClass, true)) {
+        // warm up both factory-backed services and bare-registered classes of the contract
+        $knownClasses = [...array_keys($this->serviceFactories), ...array_keys($this->registeredClasses)];
+
+        foreach ($knownClasses as $knownClass) {
+            if (! is_a($knownClass, $contractClass, true)) {
                 continue;
             }
 
-            if (isset($this->instances[$class])) {
+            if (isset($this->instances[$knownClass])) {
                 continue;
             }
 
             // warm up cache if not yet
-            $this->instances[$class] = $this->make($class);
+            $this->instances[$knownClass] = $this->make($knownClass);
         }
     }
 

--- a/tests/Container/Container/ContainerDiscoveryTest.php
+++ b/tests/Container/Container/ContainerDiscoveryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Entropy\Tests\Container\Container;
+
+use Entropy\Container\Container;
+use Entropy\Tests\Container\Container\Fixture\CollectedInterface;
+use Entropy\Tests\Container\Container\Fixture\FirstCollected;
+use Entropy\Tests\Container\Container\Fixture\SecondCollected;
+use PHPUnit\Framework\TestCase;
+
+final class ContainerDiscoveryTest extends TestCase
+{
+    public function testRegisterMakesClassDiscoverableByContract(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+        $container->register(SecondCollected::class);
+
+        $collected = $container->findByContract(CollectedInterface::class);
+
+        $this->assertCount(2, $collected);
+        $this->assertContainsOnlyInstancesOf(CollectedInterface::class, $collected);
+    }
+
+    public function testRegisterIsIdempotent(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+        $container->register(FirstCollected::class);
+
+        $collected = $container->findByContract(CollectedInterface::class);
+
+        $this->assertCount(1, $collected);
+    }
+
+    public function testFindByContractReturnsList(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+        $container->register(SecondCollected::class);
+
+        $collected = $container->findByContract(CollectedInterface::class);
+
+        $this->assertSame([0, 1], array_keys($collected));
+    }
+}

--- a/tests/Container/Container/Fixture/CollectedInterface.php
+++ b/tests/Container/Container/Fixture/CollectedInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Entropy\Tests\Container\Container\Fixture;
+
+interface CollectedInterface
+{
+}

--- a/tests/Container/Container/Fixture/FirstCollected.php
+++ b/tests/Container/Container/Fixture/FirstCollected.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Entropy\Tests\Container\Container\Fixture;
+
+final class FirstCollected implements CollectedInterface
+{
+}

--- a/tests/Container/Container/Fixture/SecondCollected.php
+++ b/tests/Container/Container/Fixture/SecondCollected.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Entropy\Tests\Container\Container\Fixture;
+
+final class SecondCollected implements CollectedInterface
+{
+}


### PR DESCRIPTION
Two small, general container features so an application can resolve collaborators **by interface contract** without keeping its own registry bolted onto the container. Extracted from bridging `rector/rector-src` onto entropy.

## 1. `register(class)` — factory-less registration for discovery

`findByContract()` only warmed factory-backed services, so a class registered as bare autowire was invisible until something happened to `make()` it. `register()` records the class so discovery finds it:

```php
$container->register(FirstCollected::class);
$container->register(SecondCollected::class);

$container->findByContract(CollectedInterface::class); // [FirstCollected, SecondCollected]
```

Idempotent (unlike `service()`, which throws on re-register). A class later given a factory via `service()` wins.

## 2. `findByContract()` returns a 0-indexed list

It returned an `array_filter()` result — **class-string keyed**. Spreading that into a variadic turns the keys into named arguments:

```php
new NodeTraverser(...$container->findByContract(VisitorInterface::class));
// keys 'App\FooVisitor' => ... become named args -> breakage
```

Now returns `array_values(...)` — a plain list.

## Tests / checks

- `tests/Container/Container/ContainerDiscoveryTest.php` covers discovery, idempotent register, and the list result
- full suite green (91 tests), PHPStan level 8, ECS, rector, dependency-analyser all clean

_A follow-up may add an `afterResolving()` post-build hook for setter injection, but that is more opinionated, so it is kept out of this PR._
