### PR TITLE
Add forgetByContract() to remove services by interface

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -206,6 +206,33 @@ class Container
     }
 
     /**
+     * Forget every factory, discovery registration and cached instance whose class is-a $contract,
+     * so make() and findByContract() no longer return them. A later make() rebuilds a fresh instance.
+     *
+     * @param class-string $contract
+     */
+    public function forgetByContract(string $contract): void
+    {
+        foreach (array_keys($this->serviceFactories) as $class) {
+            if (is_a($class, $contract, true)) {
+                unset($this->serviceFactories[$class]);
+            }
+        }
+
+        foreach (array_keys($this->registeredClasses) as $class) {
+            if (is_a($class, $contract, true)) {
+                unset($this->registeredClasses[$class]);
+            }
+        }
+
+        foreach (array_keys($this->instances) as $class) {
+            if (is_a($class, $contract, true)) {
+                unset($this->instances[$class]);
+            }
+        }
+    }
+
+    /**
      * @param ReflectionParameter[] $reflectionParameters
      * @param class-string $class
      * @return array<object|object[]>

--- a/tests/Container/Container/ContainerDiscoveryTest.php
+++ b/tests/Container/Container/ContainerDiscoveryTest.php
@@ -45,4 +45,29 @@ final class ContainerDiscoveryTest extends TestCase
 
         $this->assertSame([0, 1], array_keys($collected));
     }
+
+    public function testForgetByContractRemovesRegisteredImplementations(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+        $container->register(SecondCollected::class);
+
+        $this->assertCount(2, $container->findByContract(CollectedInterface::class));
+
+        $container->forgetByContract(CollectedInterface::class);
+
+        $this->assertCount(0, $container->findByContract(CollectedInterface::class));
+    }
+
+    public function testForgetByContractRebuildsFreshInstance(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+
+        $firstInstance = $container->make(FirstCollected::class);
+        $container->forgetByContract(CollectedInterface::class);
+        $secondInstance = $container->make(FirstCollected::class);
+
+        $this->assertNotSame($firstInstance, $secondInstance);
+    }
 }


### PR DESCRIPTION
Adds `forgetByContract(string $contract)` — removes every factory, discovery registration (`register()`) and cached instance whose class is-a the contract, so `make()` and `findByContract()` no longer return them. A later `make()` rebuilds a fresh instance.

```php
$container->register(FirstCollected::class);
$container->findByContract(CollectedInterface::class); // [FirstCollected]

$container->forgetByContract(CollectedInterface::class);
$container->findByContract(CollectedInterface::class); // []
```

Motivation: an application that skips or reloads a group of services (e.g. rector dropping a rule, or a test rebooting a fresh config) currently has to reach into the container's private storage by reflection to remove them. This gives it a supported method.

Tests cover removal by contract and fresh rebuild after forget. Full suite green, PHPStan 8, ECS, rector, dependency-analyser clean.