### PR TITLE
Add afterResolving() post-build hook with deferred draining

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -53,6 +53,24 @@ class Container
      */
     private array $registeredClasses = [];
 
+    /**
+     * Callbacks run once, right after a matching instance is built, keyed by the type they apply to.
+     * @var array<class-string, list<callable(object, self): void>>
+     */
+    private array $afterResolvingCallbacks = [];
+
+    /**
+     * Instances built during the current top-level make() that still wait for their afterResolving
+     * callbacks. Draining is deferred to the outermost make() so a service and the collection it
+     * belongs to can resolve without tripping the circular-dependency guard.
+     * @var list<object>
+     */
+    private array $pendingAfterResolving = [];
+
+    private int $resolutionDepth = 0;
+
+    private bool $isDraining = false;
+
     public function __construct()
     {
         // setup default console service
@@ -129,6 +147,29 @@ class Container
     }
 
     /**
+     * Register a callback run once, right after an instance of $class (or a subtype) is built.
+     * Useful for setter injection that would otherwise create a dependency cycle. Draining is
+     * deferred to the outermost make(), so the callback can resolve the collection $class belongs to.
+     *
+     * @template TObject of object
+     * @param class-string<TObject> $class
+     * @param callable(TObject, self): void $callback
+     */
+    public function afterResolving(string $class, callable $callback): void
+    {
+        // wrap in a widening closure so the heterogeneous store stays type-safe; the guard narrows
+        // the built instance back to TObject before handing it to the typed callback
+        $this->afterResolvingCallbacks[$class][] = function (object $instance, self $container) use (
+            $callback,
+            $class
+        ): void {
+            if ($instance instanceof $class) {
+                $callback($instance, $container);
+            }
+        };
+    }
+
+    /**
      * @template TType as object
      *
      * @param class-string<TType> $class
@@ -155,6 +196,7 @@ class Container
         // mark as "currently being created"
         $this->making[$class] = true;
         $this->makingStack[] = $class;
+        ++$this->resolutionDepth;
 
         try {
             // factories / registered services
@@ -163,6 +205,7 @@ class Container
 
                 $instance = $factory($this);
                 $this->instances[$class] = $instance;
+                $this->queueAfterResolving($instance);
 
                 return $instance;
             }
@@ -173,6 +216,7 @@ class Container
             if ($reflectionClass->isInstantiable()) {
                 $instance = $this->createInstanceFromReflection($reflectionClass);
                 $this->instances[$class] = $instance;
+                $this->queueAfterResolving($instance);
 
                 return $instance;
             }
@@ -182,6 +226,13 @@ class Container
             // always unmark, even if construction throws
             array_pop($this->makingStack);
             unset($this->making[$class]);
+
+            // drain queued callbacks once the outermost make() has unwound, so their re-entrant
+            // lookups see fully built instances instead of hitting the circular-dependency guard
+            --$this->resolutionDepth;
+            if ($this->resolutionDepth === 0 && ! $this->isDraining) {
+                $this->drainAfterResolving();
+            }
         }
     }
 
@@ -270,6 +321,39 @@ class Container
 
             // warm up cache if not yet
             $this->instances[$knownClass] = $this->make($knownClass);
+        }
+    }
+
+    private function queueAfterResolving(object $instance): void
+    {
+        foreach (array_keys($this->afterResolvingCallbacks) as $registeredClass) {
+            if ($instance instanceof $registeredClass) {
+                $this->pendingAfterResolving[] = $instance;
+                return;
+            }
+        }
+    }
+
+    private function drainAfterResolving(): void
+    {
+        $this->isDraining = true;
+
+        try {
+            while ($this->pendingAfterResolving !== []) {
+                $instance = array_shift($this->pendingAfterResolving);
+
+                foreach ($this->afterResolvingCallbacks as $registeredClass => $callbacks) {
+                    if (! $instance instanceof $registeredClass) {
+                        continue;
+                    }
+
+                    foreach ($callbacks as $callback) {
+                        $callback($instance, $this);
+                    }
+                }
+            }
+        } finally {
+            $this->isDraining = false;
         }
     }
 

--- a/tests/Container/Container/ContainerDiscoveryTest.php
+++ b/tests/Container/Container/ContainerDiscoveryTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Entropy\Tests\Container\Container;
 
 use Entropy\Container\Container;
+use Entropy\Tests\Container\Container\Fixture\CollectedAggregate;
 use Entropy\Tests\Container\Container\Fixture\CollectedInterface;
 use Entropy\Tests\Container\Container\Fixture\FirstCollected;
 use Entropy\Tests\Container\Container\Fixture\SecondCollected;
+use Entropy\Tests\Container\Container\Fixture\SomeType;
 use PHPUnit\Framework\TestCase;
 
 final class ContainerDiscoveryTest extends TestCase
@@ -69,5 +71,44 @@ final class ContainerDiscoveryTest extends TestCase
         $secondInstance = $container->make(FirstCollected::class);
 
         $this->assertNotSame($firstInstance, $secondInstance);
+    }
+
+    public function testAfterResolvingRunsOncePerInstance(): void
+    {
+        $container = new Container();
+
+        $callCount = 0;
+        $container->afterResolving(SomeType::class, function (SomeType $someType, Container $container) use (
+            &$callCount
+        ): void {
+            ++$callCount;
+        });
+
+        $container->make(SomeType::class);
+        $container->make(SomeType::class);
+
+        $this->assertSame(1, $callCount);
+    }
+
+    public function testAfterResolvingBreaksAggregateCycle(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+        $container->register(SecondCollected::class);
+
+        $container->afterResolving(CollectedInterface::class, function (
+            CollectedInterface $collected,
+            Container $container
+        ): void {
+            if ($collected instanceof FirstCollected) {
+                $collected->setCollectedAggregate($container->make(CollectedAggregate::class));
+            }
+        });
+
+        $collectedAggregate = $container->make(CollectedAggregate::class);
+        $this->assertCount(2, $collectedAggregate->getCollected());
+
+        $firstCollected = $container->make(FirstCollected::class);
+        $this->assertSame($collectedAggregate, $firstCollected->getCollectedAggregate());
     }
 }

--- a/tests/Container/Container/Fixture/CollectedAggregate.php
+++ b/tests/Container/Container/Fixture/CollectedAggregate.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Entropy\Tests\Container\Container\Fixture;
+
+final class CollectedAggregate
+{
+    /**
+     * @param CollectedInterface[] $collected
+     */
+    public function __construct(
+        private array $collected
+    ) {
+    }
+
+    /**
+     * @return CollectedInterface[]
+     */
+    public function getCollected(): array
+    {
+        return $this->collected;
+    }
+}

--- a/tests/Container/Container/Fixture/FirstCollected.php
+++ b/tests/Container/Container/Fixture/FirstCollected.php
@@ -6,4 +6,15 @@ namespace Entropy\Tests\Container\Container\Fixture;
 
 final class FirstCollected implements CollectedInterface
 {
+    private ?CollectedAggregate $collectedAggregate = null;
+
+    public function setCollectedAggregate(CollectedAggregate $collectedAggregate): void
+    {
+        $this->collectedAggregate = $collectedAggregate;
+    }
+
+    public function getCollectedAggregate(): ?CollectedAggregate
+    {
+        return $this->collectedAggregate;
+    }
 }


### PR DESCRIPTION
Adds `afterResolving(string $class, callable $callback)` — runs the callback once, right after an instance of `$class` (or a subtype) is built. Useful for setter injection that a constructor cannot express.

```php
$container->afterResolving(SomeRule::class, function (SomeRule $rule, Container $container): void {
    $rule->autowire($container->make(Dependency::class));
});
```

Fires **once per instance** (queued on construction, and the container caches, so it never re-fires). Callbacks are **drained only when the outermost `make()` unwinds**, so a service and the collection it belongs to resolve without tripping the circular-dependency guard:

```php
$container->afterResolving(MapperInterface::class, fn ($m, $c) => $m->setAggregate($c->make(Aggregate::class)));
$container->make(Aggregate::class); // Aggregate needs MapperInterface[]; resolves, no cycle throw
```

Tests cover once-only firing and the aggregate-cycle break. Full suite green (15 container tests), PHPStan 8, ECS, rector, dependency-analyser clean.