### PR TITLE
Fail loud when a contract implementation is registered after injection

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -54,6 +54,14 @@ class Container
     private array $registeredClasses = [];
 
     /**
+     * Contracts already materialised by findByContract(). Registering a fresh implementation of
+     * one of these afterwards is refused: the collection that consumed the contract is a snapshot
+     * and would silently miss the late class.
+     * @var array<class-string, true>
+     */
+    private array $resolvedContracts = [];
+
+    /**
      * Callbacks run once, right after a matching instance is built, keyed by the type they apply to.
      * @var array<class-string, list<callable(object, self): void>>
      */
@@ -119,6 +127,8 @@ class Container
      */
     public function service(string $class, callable $factory): void
     {
+        $this->assertNoLateContractRegistration($class);
+
         if (isset($this->serviceFactories[$class])) {
             // avoid service override
             throw new RegisterServiceException(sprintf('Service for "%s" class is already registered', $class));
@@ -142,6 +152,8 @@ class Container
         if (isset($this->serviceFactories[$class])) {
             return;
         }
+
+        $this->assertNoLateContractRegistration($class);
 
         $this->registeredClasses[$class] = true;
     }
@@ -281,6 +293,40 @@ class Container
                 unset($this->instances[$class]);
             }
         }
+
+        // the snapshot is gone, so re-registering members of this contract is allowed again
+        unset($this->resolvedContracts[$contract]);
+    }
+
+    /**
+     * Refuse a registration that arrives after its contract was already materialised by
+     * findByContract(): the consumer holds a snapshot and would never see the new class.
+     * Re-registering an already-known class is fine, it does not change any collection.
+     *
+     * @param class-string $class
+     */
+    private function assertNoLateContractRegistration(string $class): void
+    {
+        if (isset($this->serviceFactories[$class]) || isset($this->registeredClasses[$class]) || isset(
+            $this->instances[$class]
+        )) {
+            return;
+        }
+
+        foreach (array_keys($this->resolvedContracts) as $contract) {
+            if (! is_a($class, $contract, true)) {
+                continue;
+            }
+
+            throw new RegisterServiceException(sprintf(
+                'Class "%s" is registered after its contract "%s" was already resolved via findByContract(). '
+                . 'The consumer of that contract holds a snapshot and would silently miss this class. '
+                . 'Register it before the first findByContract("%s") call.',
+                $class,
+                $contract,
+                $contract
+            ));
+        }
     }
 
     /**
@@ -297,9 +343,16 @@ class Container
 
         $dependencies = [];
         foreach ($parameterTypes as $parameterType) {
-            $dependencies[] = is_array($parameterType) ? $this->findByContract($parameterType[0]) : $this->make(
-                $parameterType
-            );
+            if (! is_array($parameterType)) {
+                $dependencies[] = $this->make($parameterType);
+                continue;
+            }
+
+            $dependencies[] = $this->findByContract($parameterType[0]);
+
+            // the collection is now frozen inside the consumer being built; a later registration of a
+            // fresh implementation would be silently missed, so refuse it from here on
+            $this->resolvedContracts[$parameterType[0]] = true;
         }
 
         return $dependencies;

--- a/tests/Container/Container/ContainerDiscoveryTest.php
+++ b/tests/Container/Container/ContainerDiscoveryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Entropy\Tests\Container\Container;
 
 use Entropy\Container\Container;
+use Entropy\Container\Exception\RegisterServiceException;
 use Entropy\Tests\Container\Container\Fixture\CollectedAggregate;
 use Entropy\Tests\Container\Container\Fixture\CollectedInterface;
 use Entropy\Tests\Container\Container\Fixture\FirstCollected;
@@ -71,6 +72,45 @@ final class ContainerDiscoveryTest extends TestCase
         $secondInstance = $container->make(FirstCollected::class);
 
         $this->assertNotSame($firstInstance, $secondInstance);
+    }
+
+    public function testRegisteringImplementationAfterContractInjectedThrows(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+
+        // building the aggregate freezes the CollectedInterface collection inside it
+        $container->make(CollectedAggregate::class);
+
+        $this->expectException(RegisterServiceException::class);
+        $container->register(SecondCollected::class);
+    }
+
+    public function testDirectFindByContractDoesNotFreezeRegistration(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+
+        // a transient query, not an injection, so later registrations are still allowed
+        $this->assertCount(1, $container->findByContract(CollectedInterface::class));
+
+        $container->register(SecondCollected::class);
+
+        $this->assertCount(2, $container->findByContract(CollectedInterface::class));
+    }
+
+    public function testForgetByContractUnfreezesRegistration(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+        $container->make(CollectedAggregate::class);
+
+        $container->forgetByContract(CollectedInterface::class);
+
+        // the snapshot is gone, so registering an implementation again is allowed
+        $container->register(SecondCollected::class);
+
+        $this->assertCount(1, $container->findByContract(CollectedInterface::class));
     }
 
     public function testAfterResolvingRunsOncePerInstance(): void


### PR DESCRIPTION
## Problem

`findByContract()` materialises a collection at the moment it is called. When that collection is **injected into a constructor**, the consumer keeps a frozen snapshot. Any implementation of the same contract registered *afterwards* was **silently dropped** — no error, no warning, just missing behavior.

This bit rector: a `DecoratingNodeVisitorInterface` registered after `PHPStanNodeScopeResolver` was first built never joined its `NodeTraverser`.

```php
$container->register(FirstVisitor::class);
$consumer = $container->make(VisitorAggregate::class); // collection frozen here

$container->register(LateVisitor::class);              // was: silently ignored
$container->make(VisitorAggregate::class)->getVisitors(); // -> only FirstVisitor
```

## Fix

Mark a contract as *resolved* only when it is **injected as a collection** (not on transient `findByContract()` queries), and refuse a later `register()` / `service()` of a fresh implementation of it:

```php
$container->register(FirstVisitor::class);
$container->make(VisitorAggregate::class);

$container->register(LateVisitor::class);
// RegisterServiceException: Class "LateVisitor" is registered after its
// contract "VisitorInterface" was already resolved via findByContract().
// The consumer of that contract holds a snapshot and would silently miss
// this class. Register it before the first findByContract("VisitorInterface") call.
```

A silent, order-dependent miss becomes a loud, actionable error at registration time.

### Kept working

- Direct `findByContract()` calls stay transient — they do **not** freeze registration, so query-then-register flows (e.g. `assertEmpty(findByContract(...))` before rules load) are unaffected.
- `forgetByContract()` clears the mark, so a rebuilt collection can accept implementations again.
- Re-registering an already-known class is a no-op, never an error.

## Tests

Added to `ContainerDiscoveryTest`:
- registering an implementation after the contract is injected throws
- direct `findByContract()` does not freeze registration
- `forgetByContract()` unfreezes registration

Verified against `rector/rector-src`: full `tests/` + `rules-tests/` (4591 tests) green with this change vendored in.
