### PR TITLE
Add boot() registration barrier with reopen() to the container

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -54,6 +54,13 @@ class Container
     private array $registeredClasses = [];
 
     /**
+     * Once booted, the service graph is frozen: no further register()/service() is accepted, so any
+     * collection resolved afterwards via findByContract() is complete and order-independent. Call
+     * reopen() to register again (e.g. a reused container that re-imports a fresh config).
+     */
+    private bool $isBooted = false;
+
+    /**
      * Callbacks run once, right after a matching instance is built, keyed by the type they apply to.
      * @var array<class-string, list<callable(object, self): void>>
      */
@@ -119,6 +126,8 @@ class Container
      */
     public function service(string $class, callable $factory): void
     {
+        $this->assertNotBooted($class);
+
         if (isset($this->serviceFactories[$class])) {
             // avoid service override
             throw new RegisterServiceException(sprintf('Service for "%s" class is already registered', $class));
@@ -143,7 +152,37 @@ class Container
             return;
         }
 
+        // re-registering an already-known class changes no collection, so allow it even after boot
+        if (isset($this->registeredClasses[$class])) {
+            return;
+        }
+
+        $this->assertNotBooted($class);
+
         $this->registeredClasses[$class] = true;
+    }
+
+    /**
+     * Freeze the service graph. After this, register()/service() of a new class is refused, so every
+     * collection resolved via findByContract() from now on is complete regardless of resolution order.
+     */
+    public function boot(): void
+    {
+        $this->isBooted = true;
+    }
+
+    /**
+     * Re-open the graph for registration after a boot(). Meant for a reused container that discards its
+     * previous config and imports a fresh one (e.g. the test harness), not for production wiring.
+     */
+    public function reopen(): void
+    {
+        $this->isBooted = false;
+    }
+
+    public function isBooted(): bool
+    {
+        return $this->isBooted;
     }
 
     /**
@@ -303,6 +342,22 @@ class Container
         }
 
         return $dependencies;
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function assertNotBooted(string $class): void
+    {
+        if (! $this->isBooted) {
+            return;
+        }
+
+        throw new RegisterServiceException(sprintf(
+            'Class "%s" cannot be registered after the container was booted. Register every service before '
+            . 'boot(), so contract collections resolve completely. Call reopen() first if you must register again.',
+            $class
+        ));
     }
 
     private function warmUpInstanceServices(string $contractClass): void

--- a/tests/Container/Container/ContainerDiscoveryTest.php
+++ b/tests/Container/Container/ContainerDiscoveryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Entropy\Tests\Container\Container;
 
 use Entropy\Container\Container;
+use Entropy\Container\Exception\RegisterServiceException;
 use Entropy\Tests\Container\Container\Fixture\CollectedAggregate;
 use Entropy\Tests\Container\Container\Fixture\CollectedInterface;
 use Entropy\Tests\Container\Container\Fixture\FirstCollected;
@@ -14,6 +15,61 @@ use PHPUnit\Framework\TestCase;
 
 final class ContainerDiscoveryTest extends TestCase
 {
+    public function testIsBootedReflectsState(): void
+    {
+        $container = new Container();
+        $this->assertFalse($container->isBooted());
+
+        $container->boot();
+        $this->assertTrue($container->isBooted());
+
+        $container->reopen();
+        $this->assertFalse($container->isBooted());
+    }
+
+    public function testRegisterAfterBootThrows(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+        $container->boot();
+
+        $this->expectException(RegisterServiceException::class);
+        $container->register(SecondCollected::class);
+    }
+
+    public function testServiceAfterBootThrows(): void
+    {
+        $container = new Container();
+        $container->boot();
+
+        $this->expectException(RegisterServiceException::class);
+        $container->service(SomeType::class, static fn (): SomeType => new SomeType());
+    }
+
+    public function testReRegisteringKnownClassAfterBootIsAllowed(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+        $container->boot();
+
+        // re-registering an already-known class changes no collection, so it must not throw
+        $container->register(FirstCollected::class);
+
+        $this->assertCount(1, $container->findByContract(CollectedInterface::class));
+    }
+
+    public function testReopenAllowsRegistrationAgain(): void
+    {
+        $container = new Container();
+        $container->register(FirstCollected::class);
+        $container->boot();
+
+        $container->reopen();
+        $container->register(SecondCollected::class);
+
+        $this->assertCount(2, $container->findByContract(CollectedInterface::class));
+    }
+
     public function testRegisterMakesClassDiscoverableByContract(): void
     {
         $container = new Container();


### PR DESCRIPTION
## Problem

`findByContract()` collects a contract's implementations at the moment it is called. When that collection is injected into a long-lived service, the service keeps a **snapshot** — any implementation registered *afterwards* is silently missed. Nothing tells you; the collection is just quietly incomplete, and the outcome depends on registration vs. resolution order.

## Fix: an explicit boot lifecycle

Register everything, then `boot()`. After boot the graph is **frozen**: registering a *new* class throws, so any collection resolved after boot is complete and order-independent.

```php
$container->register(FirstVisitor::class);
$container->register(SecondVisitor::class);
$container->boot();                    // graph frozen

$container->findByContract(VisitorInterface::class); // complete, always

$container->register(LateVisitor::class);
// RegisterServiceException: Class "LateVisitor" cannot be registered after
// the container was booted. Register every service before boot(), so contract
// collections resolve completely. Call reopen() first if you must register again.
```

`reopen()` lifts the freeze for a **reused** container that discards its config and imports a fresh one (e.g. a test harness that runs many rule-configs against one container):

```php
$container->boot();
$container->reopen();                  // registration open again
$container->register(LateVisitor::class);   // ok
$container->boot();                    // freeze again
```

## API

- `boot(): void` — freeze the graph.
- `reopen(): void` — lift the freeze (reused containers only).
- `isBooted(): bool` — current state.

Re-registering an **already-known** class stays a no-op (changes no collection), so it never throws — only a genuinely new class after boot does.

## Tests

Added to `ContainerDiscoveryTest`:
- `isBooted()` reflects boot/reopen state
- `register()` / `service()` of a new class after boot throws
- re-registering a known class after boot is allowed
- `reopen()` allows registration again, and the collection then includes the new class

100 tests green, ECS + PHPStan clean.
