### PR TITLE
Make sure `contentWidth` is at least 0

### DIFF
--- a/src/Console/Output/OutputPrinter.php
+++ b/src/Console/Output/OutputPrinter.php
@@ -152,7 +152,7 @@ final readonly class OutputPrinter
     private function block(string $text, string $color): void
     {
         // reserve 2 chars for the single space padding the background() adds on each side
-        $contentWidth = Terminal::getWidth() - 2;
+        $contentWidth = max(0, Terminal::getWidth() - 2);
 
         $emptyLine = str_repeat(' ', $contentWidth);
         $paddedText = Terminal::padVisibleRight($text, $contentWidth);


### PR DESCRIPTION
### Description

Hey Tomas!

Lately, our CI is breaking with the following error when using [ecsphp/ecs(symplify/ecs)](https://github.com/ecsphp/ecs-src)

One of the latest runs:
(https://github.com/contao/contao/actions/runs/32863995956/job/97854631899?pr=10134)

```bash
Run failed: str_repeat(): Argument #2 ($times) must be greater than or equal to 0
``` 

The cause is `COLUMNS` having 0 width in the CI, resulting in `-2` which will error in the str_repeat. Using `max(0, Terminal::getWidth() - 2)` will make sure we are always at least at 0 as `times` `has to be greater than or equal to 0` (see https://www.php.net/manual/en/function.str-repeat.php) 

Simple producer for letting it fail would be using the following command (or the modified one for your path) in your CLI:

```bash
env COLUMNS=0 vendor-bin/ecs/vendor/bin/ecs check --no-progress-bar
```
leading to

```
Run failed: str_repeat(): Argument #2 ($times) must be greater than or equal to 0 
```

<details>

<summary>Stacktrace</summary>

```bash
#0 /Users/zoglo/Projects/contao/vendor-bin/ecs/vendor/symplify/easy-coding-standard/vendor/entropy/entropy/src/Console/Output/OutputPrinter.php(136): str_repeat(' ', -2)
#1 /Users/zoglo/Projects/contao/vendor-bin/ecs/vendor/symplify/easy-coding-standard/vendor/entropy/entropy/src/Console/Output/OutputPrinter.php(99): ECSPrefix202608\Entropy\Console\Output\OutputPrinter->block('[OK] No errors ...', 'green')
#2 /Users/zoglo/Projects/contao/vendor-bin/ecs/vendor/symplify/easy-coding-standard/src/Console/Style/EasyCodingStandardStyle.php(51): ECSPrefix202608\Entropy\Console\Output\OutputPrinter->success('No errors found...')
#3 /Users/zoglo/Projects/contao/vendor-bin/ecs/vendor/symplify/easy-coding-standard/src/Console/Output/ConsoleOutputFormatter.php(44): Symplify\EasyCodingStandard\Console\Style\EasyCodingStandardStyle->success('No errors found...')
#4 /Users/zoglo/Projects/contao/vendor-bin/ecs/vendor/symplify/easy-coding-standard/src/Reporter/ProcessedFileReporter.php(40): Symplify\EasyCodingStandard\Console\Output\ConsoleOutputFormatter->report(Object(Symplify\EasyCodingStandard\ValueObject\Error\ErrorAndDiffResult), Object(Symplify\EasyCodingStandard\ValueObject\Configuration))
#5 /Users/zoglo/Projects/contao/vendor-bin/ecs/vendor/symplify/easy-coding-standard/src/Console/Command/CheckCommand.php(86): Symplify\EasyCodingStandard\Reporter\ProcessedFileReporter->report(Array, Object(Symplify\EasyCodingStandard\ValueObject\Configuration))
#6 /Users/zoglo/Projects/contao/vendor-bin/ecs/vendor/symplify/easy-coding-standard/vendor/entropy/entropy/src/Console/ConsoleApplication.php(95): Symplify\EasyCodingStandard\Console\Command\CheckCommand->run(false, false, true, false, false, false, '', 'console', '', '', '')
#7 /Users/zoglo/Projects/contao/vendor-bin/ecs/vendor/symplify/easy-coding-standard/bin/ecs.php(154): ECSPrefix202608\Entropy\Console\ConsoleApplication->run(Array)
#8 /Users/zoglo/Projects/contao/vendor-bin/ecs/vendor/symplify/easy-coding-standard/bin/ecs(5): require('/Users/zoglo/Pr...')
#9 /Users/zoglo/Projects/contao/vendor-bin/ecs/vendor/bin/ecs(119): include('/Users/zoglo/Pr...')
#10 {main}
```

</details>