### PR TITLE
Avoid deprecated ReflectionType __toString() cast

### DIFF
--- a/src/Reflection/ParameterTypesResolver.php
+++ b/src/Reflection/ParameterTypesResolver.php
@@ -39,7 +39,7 @@ final class ParameterTypesResolver
                 continue;
             } else {
                 // try resolving array of class types via docblock
-                if ($parameterType instanceof ReflectionNamedType && (string) $reflectionParameter->getType() === 'array') {
+                if ($parameterType instanceof ReflectionNamedType && $parameterType->getName() === 'array') {
                     $docComment = $reflectionMethod->getDocComment();
                     if ($docComment !== false) {
                         $pattern = sprintf('/@param\s+%s\[\]\s+\$%s/', '([\\\\\w]+)', $reflectionParameter->getName());


### PR DESCRIPTION
Fixes #21.

`(string) $reflectionParameter->getType()` implicitly calls the deprecated `ReflectionType::__toString()`, which emits a deprecation warning under PHP 7.4.

At that point `$parameterType` is already narrowed to `ReflectionNamedType`, so use `$parameterType->getName()` directly for the `'array'` comparison.

https://claude.ai/code/session_013JhNDdVPANLqvgHobLyBMV